### PR TITLE
Handle missing RAWG key errors gracefully

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -34,8 +34,28 @@ function badge(text){
 
 async function fetchJSON(url, opts) {
   const res = await fetch(url, opts);
-  if (!res.ok) throw new Error(await res.text());
-  return res.json();
+  const text = await res.text();
+  let data;
+  if (text) {
+    try {
+      data = JSON.parse(text);
+    } catch {
+      data = text;
+    }
+  }
+  if (!res.ok) {
+    const message = typeof data === 'object' && data !== null
+      ? (data.detail || data.error || JSON.stringify(data))
+      : (text || `HTTP ${res.status}`);
+    const err = new Error(message);
+    err.status = res.status;
+    if (typeof data === 'object' && data !== null) err.data = data;
+    throw err;
+  }
+  if (typeof data === 'string') {
+    throw new Error(data || 'Unexpected response');
+  }
+  return data ?? {};
 }
 
 async function loadPreferences(){
@@ -147,6 +167,7 @@ function renderGrid(games){
 
 async function doFetch(){
   notice.classList.add('hidden');
+  notice.textContent = '';
   try {
     const url = `/api/games?${new URLSearchParams({
       daysBack: daysBack.value,
@@ -158,15 +179,23 @@ async function doFetch(){
     }).toString()}`;
     const data = await fetchJSON(url);
     rangeEl.textContent = `${data.range.start} → ${data.range.end} • ${data.count} games`;
-    // Show debug hint if empty
-    if (data.count === 0 && data._debug){
+    const notes = [];
+    if (data._note) notes.push(data._note);
+    if (data.count === 0 && data._debug) {
+      notes.push(`Debug: RAWG query ${JSON.stringify(data._debug.query)}`);
+    }
+    if (notes.length) {
       notice.classList.remove('hidden');
-      notice.textContent = `Debug: RAWG query ${JSON.stringify(data._debug.query)}`;
+      notice.textContent = notes.join(' • ');
     }
     renderGrid(data.results);
   } catch (e) {
     notice.classList.remove('hidden');
-    notice.textContent = 'Error: ' + e.message + ' • Tip: check /api/health';
+    const parts = [];
+    if (e.data?.detail) parts.push(e.data.detail);
+    else if (e.message) parts.push(e.message);
+    if (e.data?._note) parts.push(e.data._note);
+    notice.textContent = `Error: ${parts.join(' • ') || 'Request failed'} • Tip: set RAWG_KEY and check /api/health`;
   }
 }
 

--- a/server.js
+++ b/server.js
@@ -106,7 +106,14 @@ function scoreGame(game, prefs) {
 
 async function rawgFetch(params) {
   if (!RAWG_KEY) {
-    return { results: [], _note: 'RAWG_KEY missing' };
+    const err = new Error('RAWG_KEY missing');
+    err.status = 500;
+    err.data = {
+      error: 'rawg_key_missing',
+      detail: 'RAWG_KEY missing',
+      _note: 'Set the RAWG_KEY environment variable before fetching from RAWG.'
+    };
+    throw err;
   }
   // Strip undefined or null
   const clean = Object.fromEntries(Object.entries(params).filter(([_,v]) => v !== undefined && v !== null && v !== ''));
@@ -191,8 +198,18 @@ app.get('/api/games', async (req, res) => {
 
     res.json({ range: { start, end }, count: scored.length, results: scored, _debug: data?._debug });
   } catch (e) {
-    console.error(e?.response?.data || e.message);
-    res.status(500).json({ error: 'fetch_failed', detail: e?.response?.data || e.message });
+    const status = e.status || e.response?.status || 500;
+    const data = (e.data && typeof e.data === 'object')
+      ? { ...e.data }
+      : (e.response?.data && typeof e.response.data === 'object')
+        ? { ...e.response.data }
+        : null;
+    const detail = data?.detail || e.message || 'fetch_failed';
+    const payload = data || {};
+    if (!payload.error) payload.error = 'fetch_failed';
+    if (!payload.detail) payload.detail = detail;
+    console.error(payload);
+    res.status(status).json(payload);
   }
 });
 
@@ -261,8 +278,18 @@ app.post('/api/daily/run', async (req, res) => {
 
     res.json({ ok: true, saved: file, count: scored.length, top5: scored.slice(0,5) });
   } catch (e) {
-    console.error(e?.response?.data || e.message);
-    res.status(500).json({ error: 'daily_failed', detail: e?.response?.data || e.message });
+    const status = e.status || e.response?.status || 500;
+    const data = (e.data && typeof e.data === 'object')
+      ? { ...e.data }
+      : (e.response?.data && typeof e.response.data === 'object')
+        ? { ...e.response.data }
+        : null;
+    const detail = data?.detail || e.message || 'daily_failed';
+    const payload = data || {};
+    if (!payload.error) payload.error = 'daily_failed';
+    if (!payload.detail) payload.detail = detail;
+    console.error(payload);
+    res.status(status).json(payload);
   }
 });
 


### PR DESCRIPTION
## Summary
- throw a descriptive RAWG_KEY missing error from the RAWG fetch helper and propagate it through the API responses
- improve the games endpoint error handling and client banner messaging so users see the backend notes when configuration is missing

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d82015c0b08326bd9812719b4a7632